### PR TITLE
Update web interface to display both background task counts

### DIFF
--- a/python/test/static/index.html
+++ b/python/test/static/index.html
@@ -42,7 +42,8 @@
           <p class="lead">Welcome to the ODIN workshop!</p>
           <p>API version is:&nbsp;<span id="api-version">&nbsp;</span></p>
           <p>Registered API adapters:&nbsp;<span id="api-adapters">&nbsp;</span></p>
-          <p>Workshop background task count:&nbsp;<span id="task-count">&nbsp;</span></p>
+          <p>Workshop background task count (ioloop):&nbsp;<span id="task-count-ioloop">&nbsp;</span></p>
+          <p>Workshop background task count (thread):&nbsp;<span id="task-count-thread">&nbsp;</span></p>
           <p>Enable background task:&nbsp;<input type="checkbox" id="task-enable" onclick="change_enable()"/></p>
         </div>
 

--- a/python/test/static/js/odin_server.js
+++ b/python/test/static/js/odin_server.js
@@ -31,9 +31,11 @@ function update_api_adapters() {
 function update_background_task() {
 
     $.getJSON('/api/' + api_version + '/workshop/background_task', function(response) {
-        var task_count = response.background_task.count;
+        var task_count_ioloop = response.background_task.ioloop_count;
+        var task_count_thread = response.background_task.thread_count;
         var task_enabled = response.background_task.enable;
-        $('#task-count').html(task_count);
+        $('#task-count-ioloop').html(task_count_ioloop);
+        $('#task-count-thread').html(task_count_thread);
         $('#task-enable').prop('checked', task_enabled);
     });
 }


### PR DESCRIPTION
There are now two background tasks counting: ioloop and thread. This was not
reflected in the web interface, but now both counts are displayed.